### PR TITLE
fix: BDX-BDEU initial liquidity updated

### DIFF
--- a/test/helpers/SystemSetup.ts
+++ b/test/helpers/SystemSetup.ts
@@ -38,7 +38,7 @@ export async function setUpFunctionalSystem(hre: HardhatRuntimeEnvironment, init
     await provideLiquidity(hre, deployer, wbtc, bdEu, to_d8(1000).mul(1e12).div(to_d12(initialWbtcBdEuPrice)), to_d18(1000));
     await provideLiquidity(hre, deployer, weth, bdx, to_d18(1000).mul(1e12).div(to_d12(initialWethBdxPrice)), to_d18(1000));
     await provideLiquidity(hre, deployer, wbtc, bdx, to_d8(1000).mul(1e12).div(to_d12(initialWbtcBdxPrice)), to_d18(1000));
-    await provideLiquidity(hre, deployer, bdx, bdEu, to_d8(1000).mul(1e12).div(to_d12(initialBdxBdEuPrice)), to_d18(1000));
+    await provideLiquidity(hre, deployer, bdx, bdEu, to_d18(1000).mul(1e12).div(to_d12(initialBdxBdEuPrice)), to_d18(1000));
 
     if (simulateTimeElapse) {
         await simulateTimeElapseInSeconds(60*60+1); // wait the uniswap pair oracle update period


### PR DESCRIPTION
It seems that there was a typo. For BDX we want 1e8 multiplier (because 1BTC = 1e8 satoshi, but for other coins, (including bdx) we want 1e18 multiplier, right?