### PR TITLE
transfer 15% (3,150,000) of the BDX tokens to the locking contract

### DIFF
--- a/deploy/1_4_transfer_bdx_to_locking_contract.ts
+++ b/deploy/1_4_transfer_bdx_to_locking_contract.ts
@@ -1,0 +1,21 @@
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeployFunction } from 'hardhat-deploy/types';
+import * as constants from '../utils/Constants'
+import { getBdx, getTreasury } from '../utils/DeployedContractsHelpers';
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+    console.log("starting: transfer BDX to locking contract");
+
+    const treasury = await getTreasury(hre);
+    const bdx = await getBdx(hre);
+    const tx = await bdx.connect(treasury).transfer(constants.rskLockingContractAddress, constants.bdxLockAmount)
+    await tx.wait();
+    
+    console.log("finished: transfer BDX to locking contract");
+    return true;
+};
+
+func.id = __filename
+func.tags = ['LockBDX'];
+func.dependencies = ['BdxMint'];
+export default func;

--- a/utils/Constants.ts
+++ b/utils/Constants.ts
@@ -93,3 +93,6 @@ export const RSK_RUSDT_ADDRESS = "0xef213441a85df4d7acbdae0cf78004e1e486bb96";
 export const RSK_WRBTC_ADDRESS = "0x542fda317318ebf1d3deaf76e0b632741a7e677d";
 export const RSK_ETHS_ADDRESS = "0x1d931bf8656d795e50ef6d639562c5bd8ac2b78f";
 export const RSK_XUSD_ADDRESS = "0xb5999795be0ebb5bab23144aa5fd6a02d080299f";
+
+export const rskLockingContractAddress = '' // TODO: Fill locking contract address after deployment
+export const bdxLockAmount = to_d18(3150000)


### PR DESCRIPTION
resolves LAGO-55
after the BDX tokens are minted to the treasury wallet, deposit 3,150,000 BDX to the locking contract.

@kazazor let's deploy the locking contract before the weekend so we will have this missing contract address in advance.