### PR TITLE
kazaz/Changed the show config of the be to return an object instead of string

### DIFF
--- a/deploy/7_deploy_price_feeds.ts
+++ b/deploy/7_deploy_price_feeds.ts
@@ -10,7 +10,7 @@ import { BdStablePool } from '../typechain/BdStablePool';
 import { DeployResult } from 'hardhat-deploy/dist/types';
 import { to_d12 } from '../utils/NumbersHelpers';
 
-export const ContractsNames : {priceFeedEurUsdName: string, priceFeedETHUsdName: string, BtcToEthOracle: string} = {
+export const ContractsNames = {
   priceFeedEurUsdName: "PriceFeed_EUR_USD",
   priceFeedETHUsdName: "PriceFeed_ETH_USD",
   BtcToEthOracle: "BtcToEthOracle"

--- a/tasks/config.ts
+++ b/tasks/config.ts
@@ -10,10 +10,7 @@ import { StakingRewards } from "../typechain/StakingRewards";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { SignerWithAddress } from "hardhat-deploy-ethers/dist/src/signers";
 import { ContractsNames as PriceFeedContractNames } from "../deploy/7_deploy_price_feeds";
-
-function cleanStringify(objectToClean: object): string {
-  return JSON.stringify(objectToClean).replace(/"([^"]+)":/g, "$1:");
-}
+import { cleanStringify } from "../utils/StringHelpers";
 
 export function load() {
     task("show:be-config").setAction(async (args, hre) => {

--- a/utils/StringHelpers.ts
+++ b/utils/StringHelpers.ts
@@ -1,0 +1,7 @@
+/**
+ * This function takes an object, stringify it and then "cleans" the output from any escape characters so the output could be later on used to paste in JS/TS code directly
+ * @param {object} objectToClean - An object to stringify and then clean.
+ */
+export function cleanStringify(objectToClean: object): string {
+  return JSON.stringify(objectToClean).replace(/"([^"]+)":/g, "$1:");
+}


### PR DESCRIPTION
## What's the purpose of your PR?

- [ ] Fixing a bug
- [ ] A new Feature
- [X] Techdebt
- [ ] General Task

## What your PR is all about?
* Changed the config from strings to object
* Made the contract names used by this task to be reused from the deployment script instead of hardcoded
* Changed the name of the configurations from `MF_` to `MAINFORK_` in order to better be ready for multi-chain. Now it takes it from the hardhat config network name.

## Any special instructions for the reviewer?
* There is a PR in the backend to also change according to the config change here: https://github.com/BlindexDAO/backend/pull/19. Please review them together.