### PR TITLE
Be able to compile multiple solidity version in the project - ignorin…

### DIFF
--- a/contracts/Oracle/AggregatorV3Interface.sol
+++ b/contracts/Oracle/AggregatorV3Interface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.6.12;
+pragma solidity ^0.6.12;
 
 interface AggregatorV3Interface {
     function decimals() external view returns (uint8);

--- a/hardhat.compile.config.ts
+++ b/hardhat.compile.config.ts
@@ -6,12 +6,23 @@ import "hardhat-deploy";
 
 export const typechainOutDir = "typechain";
 
+const solidity6Compiler = {
+  version: "0.6.12",
+  settings: {
+    optimizer: {
+      enabled: true,
+      runs: 200
+    }
+  }
+};
+
 const config: HardhatUserConfig = {
   defaultNetwork: "hardhat",
   solidity: {
     compilers: [
+      solidity6Compiler,
       {
-        version: "0.6.12",
+        version: "0.8.13",
         settings: {
           optimizer: {
             enabled: true,
@@ -19,7 +30,17 @@ const config: HardhatUserConfig = {
           }
         }
       }
-    ]
+    ],
+    overrides: {
+      "contracts/UniswapPairOracle.sol": solidity6Compiler,
+      "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol": solidity6Compiler,
+      "@uniswap/v2-core/contracts/interfaces/IUniswapV2Factory.sol": solidity6Compiler,
+      "@uniswap/v2-periphery/contracts/libraries/UniswapV2OracleLibrary.sol": solidity6Compiler,
+      "@uniswap/lib/contracts/libraries/FixedPoint.sol": solidity6Compiler,
+      "@uniswap/lib/contracts/libraries/BitMath.sol": solidity6Compiler,
+      "@uniswap/lib/contracts/libraries/FullMath.sol": solidity6Compiler,
+      "@uniswap/lib/contracts/libraries/Babylonian.sol": solidity6Compiler
+    }
   },
   typechain: {
     outDir: typechainOutDir,


### PR DESCRIPTION
…g Uniswap V2 wrong pragma definitions

## What's the purpose of your PR?

- [ ] Fixing a bug
- [ ] A new Feature
- [X] Techdebt
- [ ] General Task

## What your PR is all about?
* The way to resolve the issue was to override all the solidity pragma definitions of UniswapV2 files.
* It does not work in a recursive way, so we need to define each individual import in the imports tree
* I also defined our own file `UniswapPairOracle` to always use version 0.6.12 as we have there a desired overflow which will not work anymore in version 0.8.x as over/underflows are now protected in Solidity.
* That is also the reason why on 0.8.x `SafeMath` is no longer needed as it's just a wrapper now on top of the default defense of Solidity 0.8.x. It's still being shipped with OZ package for easier migration to 0.8.x, but it's not needed in new contracts and will be removed in future breaking change releases of OZ.

## Any special instructions for the reviewer?
